### PR TITLE
allow publishing > 127 bytes

### DIFF
--- a/src/serialiser.c
+++ b/src/serialiser.c
@@ -214,6 +214,9 @@ mqtt_serialiser_rc_t mqtt_serialiser_write(mqtt_serialiser_t* serialiser, mqtt_m
   do {
     buffer[offset++] = remaining_length & 0x7f;
     remaining_length >>= 7;
+    // Set the high bit to indicate more bits
+    if(remaining_length > 0)
+      buffer[offset-1] |= 0x80;
   } while(remaining_length > 0);
 
   switch(message->common.type) {

--- a/src/serialiser.c
+++ b/src/serialiser.c
@@ -215,8 +215,9 @@ mqtt_serialiser_rc_t mqtt_serialiser_write(mqtt_serialiser_t* serialiser, mqtt_m
     buffer[offset++] = remaining_length & 0x7f;
     remaining_length >>= 7;
     // Set the high bit to indicate more bits
-    if(remaining_length > 0)
+    if(remaining_length > 0){
       buffer[offset-1] |= 0x80;
+    }
   } while(remaining_length > 0);
 
   switch(message->common.type) {


### PR DESCRIPTION
Was using this as part of the Sming framework when I realised I couldn't publish messages greater than 127 bytes.  Some digging (and wiresharking) and I realised the length was computed incorrectly. This fix remedies it.