### PR TITLE
The initial byte doesn't count to the remaining length

### DIFF
--- a/bin/test.c
+++ b/bin/test.c
@@ -190,7 +190,7 @@ void test_parser() {
   printf("\n");
 }
 
-static void test_serialiser_procces_msg(mqtt_serialiser_t* serialiser, mqtt_message_t* message) {
+static void test_serialiser_proccess_message(mqtt_serialiser_t* serialiser, mqtt_message_t* message) {
   size_t packet_length    = mqtt_serialiser_size(serialiser, message);
   uint8_t packet[packet_length];
   mqtt_serialiser_write(serialiser, message, packet, packet_length);
@@ -230,7 +230,7 @@ void test_serialiser() {
   message.publish.content.data   = (uint8_t*)MQTT_MALLOC(3);
   memcpy(message.publish.content.data, "txt", 3);
 
-  test_serialiser_procces_msg(&serialiser, &message);
+  test_serialiser_proccess_message(&serialiser, &message);
   
   
   // PUBLISH message - size of Remaining Length field = 1 byte
@@ -247,7 +247,7 @@ void test_serialiser() {
   message.publish.content.data   = (uint8_t*)MQTT_MALLOC(3);
   memcpy(message.publish.content.data, "txt", 3);
 
-  test_serialiser_procces_msg(&serialiser, &message);
+  test_serialiser_proccess_message(&serialiser, &message);
 
 
   // PUBLISH message - size of Remaining Length field = 2 bytes 
@@ -264,7 +264,7 @@ void test_serialiser() {
   message.publish.content.data   = (uint8_t*)MQTT_MALLOC(4);
   memcpy(message.publish.content.data, "txtx", 4);
 
-  test_serialiser_procces_msg(&serialiser, &message);
+  test_serialiser_proccess_message(&serialiser, &message);
 
 
   // SUBSCRIBE message
@@ -277,13 +277,13 @@ void test_serialiser() {
   topics->next             = NULL;
   memcpy(topics->name.data, topic, topics->name.length);
   message.subscribe.topics = topics;
-  test_serialiser_procces_msg(&serialiser, &message);
+  test_serialiser_proccess_message(&serialiser, &message);
 
   
   // PINGRESP
   memset(&message, 0, sizeof(message));
   message.common.type = MQTT_TYPE_PINGRESP;
-  test_serialiser_procces_msg(&serialiser, &message);
+  test_serialiser_proccess_message(&serialiser, &message);
 
 }
 

--- a/src/serialiser.c
+++ b/src/serialiser.c
@@ -37,7 +37,7 @@
 
 #define WRITE_STRING(name)                             \
   {                                                    \
-    buffer[offset++] = name.length / 0xff;             \
+    buffer[offset++] = name.length >> 8;               \
     buffer[offset++] = name.length & 0xff;             \
     memcpy(&(buffer[offset]), name.data, name.length); \
     offset += name.length;                             \

--- a/src/serialiser.c
+++ b/src/serialiser.c
@@ -178,7 +178,6 @@ size_t mqtt_serialiser_size(mqtt_serialiser_t* serialiser, mqtt_message_t* messa
   }
 
   message->common.length = len;
-  len += 1; // initial byte with flags and type
 
   // the bytes needed for the common length
   if(len <= 127) {
@@ -190,6 +189,8 @@ size_t mqtt_serialiser_size(mqtt_serialiser_t* serialiser, mqtt_message_t* messa
   } else if(len <= 268435455) {
     len += 4;
   }
+
+  len += 1; // initial byte with flags and type
 
   return len;
 }


### PR DESCRIPTION
The Initial Byte of the MQTT message does not count to the Remaining Length. As result the calculation of the message length is wrong if the Remaining Length is exactly 127 bytes (or 16383, ...). As result the MQTT broker (in my case mosquitto) terminates the connection to the MQTT client (Client ESP8266-XXXXXX disconnected due to protocol error.).
